### PR TITLE
Use relevant extension for temporary file

### DIFF
--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -95,7 +95,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
 
 def grabclipboard():
     if sys.platform == "darwin":
-        fh, filepath = tempfile.mkstemp(".jpg")
+        fh, filepath = tempfile.mkstemp(".png")
         os.close(fh)
         commands = [
             'set theFile to (open for access POSIX file "'


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7219

Since you're getting the image data in the PNG format, let's save it to a file with the relevant extension.